### PR TITLE
Handle "script" attribute not being stored in .tscn

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -891,10 +891,24 @@ void Object::set_custom_type_script(const Variant &p_script) {
 		return;
 	}
 
-	Ref<Script> s = p_script;
-	ERR_FAIL_COND_MSG(s.is_null() && !p_script.is_null(), "Parameter should be a reference to a valid script (or null).");
+	Ref<Script> c = p_script;
+	ERR_FAIL_COND_MSG(c.is_null() && !p_script.is_null(), "Parameter should be a reference to a valid script (or null).");
 
 	custom_type_script = p_script;
+
+	// If there is already an extension script present, check if it's compatbile with
+	// the new custom type script. If it's not, fallback to the custom type script.
+	if (!custom_type_script.is_null() && !script.is_null() && script != custom_type_script) {
+		Ref<Script> s = script;
+		if (!s->inherits_script(c)) {
+			set_script(custom_type_script);
+			ERR_FAIL_MSG(s->get_path() + " is not an extension of " + c->get_global_name());
+		}
+	}
+
+	if (script.is_null()) {
+		set_script(custom_type_script);
+	}
 }
 
 void Object::set_script(const Variant &p_script) {
@@ -905,6 +919,7 @@ void Object::set_script(const Variant &p_script) {
 	Ref<Script> s = p_script;
 	ERR_FAIL_COND_MSG(s.is_null() && !p_script.is_null(), "Invalid parameter, it should be a reference to a valid script (or null).");
 
+	// Check if there is a custom type script present. If there is, then "script" cannot be null and must extend the custom type script
 	if (!custom_type_script.is_null()) {
 		if (s.is_null()) {
 			set_script(custom_type_script);


### PR DESCRIPTION
When the "script" attribute has script assigned to it and its equal to the custom type script, it will be recognized as the default property value. This leads for it not being stored in the .tscn file. Only "custom_script_type" gets stored and therefore needs to restore "script" when set.
